### PR TITLE
Import Exception from the global namespace.

### DIFF
--- a/src/Melihucar/FtpClient/FtpClient.php
+++ b/src/Melihucar/FtpClient/FtpClient.php
@@ -1,4 +1,7 @@
 <?php namespace Melihucar\FtpClient;
+
+use \Exception;
+
 /**
  * FTP Client for PHP
  * 


### PR DESCRIPTION
Change to namespaces requires that we use Exception from the global namespace.
